### PR TITLE
Ensure Xcode developer dir is sert

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,10 @@
   become: yes
   ignore_errors: yes
 
+- name: Ensure Xcode developer dir is set
+  command: xcode-select --switch /Applications/Xcode.app
+  become: true
+
 - name: Accept license (optional)
   shell: xcodebuild -license accept
   become: yes


### PR DESCRIPTION
I ran in to an issue in which the developer directory was set to something else and it caused an error in a playbook, stopping on the Accept License task. This would correct this issue and confirm that the correct directory is set. If the command fails, then the Xcode installation most likely failed and the playbook should stop anyway.